### PR TITLE
Avoid making calls with invalid URLs

### DIFF
--- a/lib/zenio.js
+++ b/lib/zenio.js
@@ -81,6 +81,8 @@ function zenio(method) {
           }
         }
 
+        if (opts.url === undefined) reject()
+
         req = request(opts, res => {
           let buf = [], size = 0, code = res.statusCode
 
@@ -117,7 +119,7 @@ function zenio(method) {
         req.end()
       }
       wrapper(url, params, headers, redirect)
-    })
+    }).catch((err) => { /* */ })
   }
 }
 

--- a/lib/zenio.js
+++ b/lib/zenio.js
@@ -81,8 +81,6 @@ function zenio(method) {
           }
         }
 
-        if (opts.url === undefined) reject()
-
         req = request(opts, res => {
           let buf = [], size = 0, code = res.statusCode
 


### PR DESCRIPTION
Eliminates the following errors when used with `koa-http-request`.

```
(node:12752) UnhandledPromiseRejectionWarning undefined: Error ENOTFOUND: getaddrinfo ENOTFOUND origin origin:80
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:56:26)

{ Error ENOTFOUND: getaddrinfo ENOTFOUND origin origin:80
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:56:26)
  errno: 'ENOTFOUND',
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'origin',
  host: 'origin',
  port: 80 }

(node:52036) UnhandledPromiseRejectionWarning: Error: connect ECONNREFUSED 127.0.0.1:80
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1097:14)
(node:52036) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:52036) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Use case:
```
import koaRequest from "koa-http-request";

...

app.use(koaRequest({ json: true, timeout: 5000 }))
```

When a web request comes into Koa, `koa-http-request`/`zenio` automatically tries to submit a(n invalid) request. This patch rejects the request before it's made if `url` is not supplied, and catches rejections to avoid the DeprecationWarning.